### PR TITLE
Allow data bag names to be attribute-configurable; defaults are backwards compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .vagrant
 Berksfile.lock
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Usage
 -----
 Include the squid recipe on the server. Other nodes may search for this node as their caching proxy and use the `node.ipaddress` and `node['squid']['port']` to point at it.
 
-Databags are able to be used for storing host & url acls and also which hosts/nets are able to access which hosts/url
+Databags are able to be used for storing host & url acls and also which hosts/nets are able to access which hosts/url. The default databag names are `squid_urls`,
+`squid_hosts`, and `squid_acls` but can be changed by setting the attributes `node['squid']['urls_data_bag_name']`, `node['squid']['hosts_data_bag_name']`, and/or
+`node['squid']['acls_data_bag_name']`, respectively.
 
 ### LDAP Authentication
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,10 @@ default['squid']['timeout'] = '10'
 default['squid']['opts'] = ''
 default['squid']['directives'] = []
 
+default['squid']['hosts_data_bag_name'] = 'squid_hosts'
+default['squid']['urls_data_bag_name'] = 'squid_urls'
+default['squid']['acls_data_bag_name'] = 'squid_acls'
+
 default['squid']['package'] = 'squid'
 default['squid']['version'] = '3.1'
 default['squid']['config_dir'] = '/etc/squid'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -2,14 +2,14 @@
 def squid_load_host_acl
   host_acl = []
   begin
-    data_bag('squid_hosts').each do |bag|
-      group = data_bag_item('squid_hosts', bag)
+    data_bag(node['squid']['hosts_data_bag_name']).each do |bag|
+      group = data_bag_item(node['squid']['hosts_data_bag_name'], bag)
       group['net'].each do |host|
         host_acl.push [group['id'], group['type'], host]
       end
     end
   rescue
-     Chef::Log.info "no 'squid_hosts' data bag"
+     Chef::Log.info "no '" + node['squid']['hosts_data_bag_name'] + "' data bag"
   end
   host_acl
 end
@@ -17,14 +17,14 @@ end
 def squid_load_url_acl
   url_acl = []
   begin
-    data_bag('squid_urls').each do |bag|
-      group = data_bag_item('squid_urls', bag)
+    data_bag(node['squid']['urls_data_bag_name']).each do |bag|
+      group = data_bag_item(node['squid']['urls_data_bag_name'], bag)
       group['urls'].each do |url|
         url_acl.push [group['id'], group.has_key?('element') ? group['element'] : node['squid']['acl_element'], url]
       end
     end
   rescue
-    Chef::Log.info "no 'squid_urls' data bag"
+    Chef::Log.info "no '" + node['squid']['urls_data_bag_name'] + "' data bag"
   end
   url_acl
 end
@@ -32,14 +32,14 @@ end
 def squid_load_acls
   acls = []
   begin
-    data_bag('squid_acls').each do |bag|
-      group = data_bag_item('squid_acls', bag)
+    data_bag(node['squid']['acls_data_bag_name']).each do |bag|
+      group = data_bag_item(node['squid']['acls_data_bag_name'], bag)
       group['acl'].each do |acl|
         acls.push [acl[1], group['id'], acl[0]]
       end
     end
   rescue
-    Chef::Log.info "no 'squid_acls' data bag"
+    Chef::Log.info "no '" + node['squid']['acls_data_bag_name'] + "' data bag"
   end
   acls
 end


### PR DESCRIPTION
This is a forward-port of a pull request submitted against 0.3.0 a while back. I think it makes sense as we manage multiple pools of squid proxies.
