### PR TITLE
Remove useless debug messages

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,6 @@ default['squid']['service_name'] = 'squid'
 default['squid']['acl_element'] = 'url_regex'
 
 default['squid']['ipaddress'] = node['ipaddress']
-default['squid']['listen_interface'] = node['network']['interfaces'].dup.reject { |k, _v| k == 'lo' }.keys.first
 default['squid']['cache_mem'] = '2048'
 default['squid']['cache_size'] = '100'
 default['squid']['max_obj_size'] = 1024
@@ -91,7 +90,4 @@ when 'rhel'
 
 when 'fedora'
   default['squid']['version'] = '3.4'
-
-when 'smartos'
-  default['squid']['listen_interface'] = 'net0'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,23 +21,12 @@
 
 # variables
 ipaddress = node['squid']['ipaddress']
-listen_interface = node['squid']['listen_interface']
 version = node['squid']['version']
-netmask = node['network']['interfaces'][listen_interface]['addresses'][ipaddress]['netmask']
 
 # squid/libraries/default.rb
 acls = squid_load_acls
 host_acl = squid_load_host_acl
 url_acl = squid_load_url_acl
-
-# Log variables to Chef::Log::debug()
-Chef::Log.debug("Squid listen_interface: #{listen_interface}")
-Chef::Log.debug("Squid ipaddress: #{ipaddress}")
-Chef::Log.debug("Squid netmask: #{netmask}")
-Chef::Log.debug("Squid version: #{version}")
-Chef::Log.debug("Squid host_acls: #{host_acl}")
-Chef::Log.debug("Squid url_acls: #{url_acl}")
-Chef::Log.debug("Squid acls: #{acls}")
 
 # packages
 package node['squid']['package']


### PR DESCRIPTION
This debug messages are causing problems on systems with multiple network interfaces - look at #32.