### PR TITLE
fix crash on empty databag

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -4,6 +4,7 @@ def squid_load_host_acl(databag_name)
   begin
     data_bag(databag_name).each do |bag|
       group = data_bag_item(databag_name, bag)
+      next unless group['net'].respond_to?(:each)
       group['net'].each do |host|
         host_acl.push [group['id'], group['type'], host]
       end
@@ -19,6 +20,7 @@ def squid_load_url_acl(databag_name)
   begin
     data_bag(databag_name).each do |bag|
       group = data_bag_item(databag_name, bag)
+      next unless group['urls'].respond_to?(:each)
       group['urls'].each do |url|
         url_acl.push [group['id'], group.key?('element') ? group['element'] : node['squid']['acl_element'], url]
       end
@@ -34,6 +36,7 @@ def squid_load_acls(databag_name)
   begin
     data_bag(databag_name).each do |bag|
       group = data_bag_item(databag_name, bag)
+      next unless group['acl'].respond_to?(:each)
       group['acl'].each do |acl|
         acls.push [acl[1], group['id'], acl[0]]
       end


### PR DESCRIPTION
When encountering an empty bag if went into rescue mode, instead of looking further for other data bags. This fixes this behavior