### PR TITLE
Enable separate 'include' conf files

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,8 @@
 # limitations under the License.
 #
 
-default['squid']['port'] = 3128
+default['squid']['port'] = '3128 options=NO_SSLv2,NO_SSLv3,NO_TLSv1'
+default['squid']['http_port'] = '3128 options=NO_SSLv2,NO_SSLv3,NO_TLSv1'
 default['squid']['network'] = nil
 default['squid']['timeout'] = '10'
 default['squid']['opts'] = ''

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['squid']['urls_databag_name'] = "squid_urls"
 default['squid']['package'] = 'squid'
 default['squid']['version'] = '3.1'
 default['squid']['config_dir'] = '/etc/squid'
+default['squid']['config_include_dir'] = '/etc/squid/conf.d'
 default['squid']['config_file'] = '/etc/squid/squid.conf'
 default['squid']['log_dir'] = '/var/log/squid'
 default['squid']['cache_dir'] = '/var/spool/squid'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,8 +19,7 @@
 # limitations under the License.
 #
 
-default['squid']['port'] = '3128 options=NO_SSLv2,NO_SSLv3,NO_TLSv1'
-default['squid']['http_port'] = '3128 options=NO_SSLv2,NO_SSLv3,NO_TLSv1'
+default['squid']['port'] = 3128
 default['squid']['network'] = nil
 default['squid']['timeout'] = '10'
 default['squid']['opts'] = ''

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -68,7 +68,7 @@ end
 
 # squid dummy include
 # required, otherwise Squid will not start due to missing .conf files
-file 'dummy.conf' do
+file "#{node['squid']['config_dir']}/dummy.conf" do
   content '# Dummy conf to enable Squid includes in conf.d'
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -68,7 +68,7 @@ end
 
 # squid dummy include
 # required, otherwise Squid will not start due to missing .conf files
-file "#{node['squid']['config_dir']}/dummy.conf" do
+file "#{node['squid']['config_include_dir']}/dummy.conf" do
   content '# Dummy conf to enable Squid includes in conf.d'
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,6 +58,14 @@ directory node['squid']['config_dir'] do
   mode 00755
 end
 
+# squid config include dir
+directory node['squid']['config_include_dir'] do
+  action :create
+  recursive true
+  owner 'root'
+  mode 00755
+end
+
 # squid mime config
 cookbook_file "#{node['squid']['config_dir']}/mime.conf" do
   source 'mime.conf'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,6 +66,13 @@ directory node['squid']['config_include_dir'] do
   mode 00755
 end
 
+# squid dummy include
+# required, otherwise Squid will not start due to missing .conf files
+file 'dummy.conf' do
+  content '# Dummy conf to enable Squid includes in conf.d'
+end
+
+
 # squid mime config
 cookbook_file "#{node['squid']['config_dir']}/mime.conf" do
   source 'mime.conf'

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -93,3 +93,6 @@ cache_mem <%= node['squid']['cache_mem'] %> MB
 <% @directives.each do |directive| %>
 <%= directive %>
 <% end %>
+
+# Include from /etc/squid/conf.d
+include /etc/squid/conf.d/*.conf


### PR DESCRIPTION
This would make it easier to include e.g. ICAP files from other cookbooks.
