### PR TITLE
Allow setting Squid's max file descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Recipes
 ### default
 The default recipe installs squid and sets up simple proxy caching. As of now, the options you may change are the port (`node['squid']['port']`) and the network the caching proxy is available on the subnet from `node.ipaddress` (ie. "192.168.1.0/24") but may be overridden with `node['squid']['network']`. The size of objects allowed to be stored has been bumped up to allow for caching of installation files.
 An optional (`node['squid']['cache_peer']`), if set, will be written verbatim to the template.
+On redhat based platforms, this cookbook supports customizing the max number of file descriptors that Squid may open (`node['squid']['max_file_descriptors']`). The default value is 1024.
 
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['squid']['network'] = nil
 default['squid']['timeout'] = '10'
 default['squid']['opts'] = ''
 default['squid']['directives'] = []
+default['squid']['max_file_descriptors'] = nil # Only supported for redhat platforms
 
 default['squid']['acls_databag_name'] = 'squid_acls'
 default['squid']['hosts_databag_name'] = 'squid_hosts'

--- a/templates/default/redhat/sysconfig/squid.erb
+++ b/templates/default/redhat/sysconfig/squid.erb
@@ -6,3 +6,7 @@ SQUID_SHUTDOWN_TIMEOUT=<%= node['squid']['timeout'] %>
 
 # default squid conf file
 SQUID_CONF="<%= node['squid']['config_file'] %>"
+
+<% if node['squid']['max_file_descriptors'] %>
+ulimit -n <%= node['squid']['max_file_descriptors'] %>
+<% end %>


### PR DESCRIPTION
Under heavy load Squid may need to open more file descriptors than the
default limit of 1024. According to Red Hat best practices, the max
file descriptors number should be increased like this.