### PR TITLE
conditional executable name based on squid version (curr: package name).

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,7 +83,8 @@ template node['squid']['config_file'] do
 end
 
 # squid swap dirs
-execute 'squid -Nz' do
+execute 'initialize squid cache dir' do
+  command "#{node['squid']['package']} -Nz"
   action :run
   creates ::File.join(node['squid']['cache_dir'], '00')
 end


### PR DESCRIPTION
When provisioning a new squid proxy, the default recipe executes this block:

    # squid swap dirs
    execute 'squid -Nz' do
      action :run
      creates ::File.join(node['squid']['cache_dir'], '00')
    end

In attributes/default.rb, we have this handy block:

    case platform_family

    when 'debian'
      default['squid']['package'] = 'squid3'

When the squid recipe is run against a Debian or Ubuntu host with no special options against a fresh host, the former block fails with a message, 'No such file or directory: squid', as there is, in fact, no such executable in the PATH, or anywhere - there is, however, a highly compatible 'squid3' executable.

This patch uses the node['squid']['package'] attribute as a stand-in for the 'squid' executable in the above block, because it was simple to implement.

I open a PR only to engage discussion, and I would be willing to do a bit of extra lifting if we agree it makes sense to implement a node['squid']['executable_name'] or somesuch variable, even if they would normally be the same.  It is possible that many changes into the future for this cookbook and the operating systems it supports, using the 'package' attribute could create confusion.