### PR TITLE
Fixing a bootstrap timing issue

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -92,4 +92,5 @@ service node['squid']['service_name'] do
   supports restart: true, status: true, reload: true
   provider Chef::Provider::Service::Upstart if platform?('ubuntu')
   action [:enable, :start]
+  retries 5
 end


### PR DESCRIPTION
Having an issue with chef-solo on Amazon Linux where the first reload request returns 1.  This fixed the issue for me.