### PR TITLE
Allow to change the logformat for access_log

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,8 @@ default['squid']['cache_size'] = '100'
 default['squid']['max_obj_size'] = 1024
 default['squid']['max_obj_size_unit'] = 'MB'
 default['squid']['enable_cache_dir'] = true
+default['squid']['logformats'] = {}
+default['squid']['access_log_option'] = 'squid'
 
 default['squid']['enable_ldap']       = false
 default['squid']['ldap_host']         = nil   # 'ldap.here.com'

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -72,7 +72,12 @@ http_port <%= node['squid']['port'] %>
 <% end %>
 
 hierarchy_stoplist cgi-bin ?
-access_log <%= node['squid']['log_dir'] %>/access.log squid
+
+<% node['squid']['logformats'].each do |name, format| %>
+logformat <%= name %> <%= format %>
+<% end -%>
+
+access_log <%= node['squid']['log_dir'] %>/access.log <%= node['squid']['access_log_option'] %>
 refresh_pattern	    ^ftp:			1440	20%	10080
 refresh_pattern     ^gopher:			1440	0%	1440
 refresh_pattern	    -i (/cgi-bin/|\?)		0	0%	0


### PR DESCRIPTION
with the current template, we cannot change the logformat for access_log.
can you add the attributes like this to allow setting custom logformat?
