### PR TITLE
Allow more customization to localnets, safe ports and ssl ports config.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,6 +36,10 @@ default['squid']['coredump_dir'] = '/var/spool/squid'
 default['squid']['service_name'] = 'squid'
 default['squid']['acl_element'] = 'url_regex'
 
+default['squid']['localnets'] = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', 'fc00::/7', 'fe80::/10']
+default['squid']['ssl_ports'] = [443, 563, 873]
+default['squid']['safe_ports'] = [80, 21, 443, 70, 210, '1025-65535', 280, 488, 591, 777, 631, 873, 901]
+
 default['squid']['ipaddress'] = node['ipaddress']
 default['squid']['listen_interface'] = node['network']['interfaces'].dup.reject { |k, _v| k == 'lo' }.keys.first
 default['squid']['cache_mem'] = '2048'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,6 +82,9 @@ template node['squid']['config_file'] do
     url_acl: url_acl,
     acls: acls,
     directives: node['squid']['directives'],
+    localnets: node['squid']['localnets'],
+    safe_ports: node['squid']['safe_ports'],
+    ssl_ports: node['squid']['ssl_ports'],
     version: package_version
   )
 end

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -16,27 +16,22 @@ auth_param basic credentialsttl <%= node['squid']['ldap_authcredentialsttl'] %>
 <%= "acl manager proto cache_object" if @version.to_f < 3.2 %>
 <%= "acl localhost src 127.0.0.1/32" if @version.to_f < 3.2 %>
 <%= "acl to_localhost dst 127.0.0.0/8 0.0.0.0/32" if @version.to_f < 3.2 %>
+<% @localnets.each do |localnet| %>
+acl localnet src <%= localnet %>
+<% end %>
+
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
 acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
 acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
 acl localnet src fc00::/7       # RFC4193 local private network range
 acl localnet src fe80::/10      # RFC4291 link-local (directly-plugged) machine
-acl SSL_ports port 443		# https
-acl SSL_ports port 563		# snews
-acl SSL_ports port 873		# rsync
-acl Safe_ports port 80		# http
-acl Safe_ports port 21		# ftp
-acl Safe_ports port 443		# https
-acl Safe_ports port 70		# gopher
-acl Safe_ports port 210		# wais
-acl Safe_ports port 1025-65535	# unregistered ports
-acl Safe_ports port 280		# http-mgmt
-acl Safe_ports port 488		# gss-http
-acl Safe_ports port 591		# filemaker
-acl Safe_ports port 777		# multiling http
-acl Safe_ports port 631		# cups
-acl Safe_ports port 873		# rsync
-acl Safe_ports port 901		# SWAT
+
+<% @ssl_ports.each do |port| %>
+acl SSL_ports port <%= port %>
+<% end %>
+<% @safe_ports.each do |port| %>
+acl Safe_ports port <%= port %>
+<% end %>
 acl purge method PURGE
 acl CONNECT method CONNECT
 
@@ -58,10 +53,10 @@ http_access deny purge
 http_access deny !Safe_ports
 http_access deny CONNECT !SSL_ports
 http_access allow localhost
-http_access allow localnet
+<%= "http_access allow localnet" if !@localnets.empty? %>
 http_access deny all
 
-icp_access allow localnet
+<%= "icp_access allow localnet" if !@localnets.empty? %>
 icp_access deny all
 <% if node['squid']['port'].kind_of?(Array) %>
   <% node['squid']['port'].each do |port| %>


### PR DESCRIPTION
### Description

Localnets, safe_ports and ssl_ports are hardcoded in squid.conf.erb, with this change it's possible to modify these values with attributes.

### Issues Resolved

None

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

