### PR TITLE
Add look-ups for squid package versions for Ubuntu LTS releases

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -5,11 +5,17 @@ module Opscode
       def squid_version
         case node['platform_family']
         when 'debian'
-          return '3.1' if node['platform_version'].to_i == 7
-          return '3.1' if node['platform_version'].to_i == 12
-          return '3.1' if node['platform_version'].to_i == 14
-          return '3.4' if node['platform_version'].to_i == 8
-          return '3.5' if node['platform_version'].to_i == 16
+          if node['platform'] == 'ubuntu'
+            return '3.1' if node['platform_version'] == '12.04'
+            return '3.3' if node['platform_version'] == '14.04'
+            return '3.5' if node['platform_version'] == '16.04'
+          else
+            return '3.1' if node['platform_version'].to_i == 7
+            return '3.1' if node['platform_version'].to_i == 12
+            return '3.1' if node['platform_version'].to_i == 14
+            return '3.4' if node['platform_version'].to_i == 8
+            return '3.5' if node['platform_version'].to_i == 16
+          end
         when 'rhel'
           return '2.6' if node['platform_version'].to_i == 5
           return '3.1' if node['platform_version'].to_i == 6


### PR DESCRIPTION
### Description

This change includes a look-up for squid major.minor versions for Ubuntu LTS releases 12.04, 14.04 and 16.10.
### Issues Resolved

Configuring squid using the cookbook at https://github.com/chef-cookbooks/squid/commit/531b09e48ea18370aef2380ed44155a5d425b637 onto an Ubuntu 14.04 LTS node results in squid (the 'squid3' service on Debian/Ubuntu nodes) failing to start with the following error:

```
  * execute[initialize squid cache dir] action run

    ================================================================================
    Error executing action `run` on resource 'execute[initialize squid cache dir]'
    ================================================================================

    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '1'
    ---- Begin output of squid3 -Nz ----
    STDOUT:
    STDERR: 2016/06/22 13:22:27| aclParseAclLine: ACL 'manager' already exists with different type.
    FATAL: Bungled /etc/squid3/squid.conf line 7: acl manager proto cache_object
    Squid Cache (Version 3.3.8): Terminated abnormally.
    CPU Usage: 0.006 seconds = 0.006 user + 0.000 sys
    Maximum Resident Size: 435760 KB
    Page faults with physical i/o: 0
    ---- End output of squid3 -Nz ----
    Ran squid3 -Nz returned 1

    Resource Declaration:
    ---------------------
    # In /opt/govukpay/chef/local-mode-cache/cache/cookbooks/squid/recipes/default.rb

     93: execute 'initialize squid cache dir' do
     94:   command "#{node['squid']['package']} -Nz"
     95:   action :run
     96:   creates ::File.join(node['squid']['cache_dir'], '00')
     97: end
```

There are several `acl` statements that are conditional on squid version at https://github.com/chef-cookbooks/squid/blob/master/templates/default/squid.conf.erb#L16, however it appears that `package_version` wasn't correctly set and so for the newer squid on 14.04, the configuration includes `acl manager proto cache_object` which is no longer required. This commit rectifies that.
### Check List

I note that tests are failing for the cookbook on Travis before I made any changes. I don't appear to have the ability to trigger those tests, but all local tests pass.
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
