### PR TITLE
Fix #68. Option to add acls using attribute node['squid']['acls']

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage
 -----
 Include the squid recipe on the server. Other nodes may search for this node as their caching proxy and use the `node.ipaddress` and `node['squid']['port']` to point at it.
 
-Databags are able to be used for storing host & url acls and also which hosts/nets are able to access which hosts/url
+Databags are able to be used for storing host & url acls and also which hosts/nets are able to access which hosts/url. Due to Chef limitations being incongruent with Squid specifications, you may also specify acls in `node['squid']['acls']`
 
 ### LDAP Authentication
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default['squid']['timeout'] = '10'
 default['squid']['opts'] = ''
 default['squid']['directives'] = []
 
+default['squid']['acls'] = []
 default['squid']['acls_databag_name'] = 'squid_acls'
 default['squid']['hosts_databag_name'] = 'squid_hosts'
 default['squid']['urls_databag_name'] = 'squid_urls'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,7 @@ netmask = node['network']['interfaces'][listen_interface]['addresses'][ipaddress
 
 # squid/libraries/default.rb
 acls = squid_load_acls(node['squid']['acls_databag_name'])
+acls += (node['squid']['acls'] || [])
 host_acl = squid_load_host_acl(node['squid']['hosts_databag_name'])
 url_acl = squid_load_url_acl(node['squid']['urls_databag_name'])
 


### PR DESCRIPTION
### Description

A work around to Chef's limitation on data bag item names not allow the Squid's "not" operator (!)
### Issues Resolved
#68
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
  Unable to test as v2.0.0 is broken with my environment Ubuntu 14.04 (see #67), however, tests are passing on v1.1.1.
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
