### PR TITLE
Detect version of squid installed. Fix issue #50

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,7 +69,8 @@ when 'debian'
   default['squid']['package'] = 'squid3'
   default['squid']['config_dir'] = '/etc/squid3'
   default['squid']['config_file'] = '/etc/squid3/squid.conf'
-  default['squid']['service_name'] = 'squid3'
+  default['squid']['service_name'] = 'squid3' if node['platform_version'].to_i <  16
+  default['squid']['service_name'] = 'squid'  if node['platform_version'].to_i >= 16
   default['squid']['log_dir'] = '/var/log/squid3'
   default['squid']['cache_dir'] = '/var/spool/squid3'
   default['squid']['coredump_dir'] = '/var/spool/squid3'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -2,25 +2,6 @@ module Opscode
   module Squid
     # helper methods for use in squid recipe code
     module Helpers
-      def squid_version
-        case node['platform_family']
-        when 'debian'
-          return '3.1' if node['platform_version'].to_i == 7
-          return '3.1' if node['platform_version'].to_i == 12
-          return '3.1' if node['platform_version'].to_i == 14
-          return '3.4' if node['platform_version'].to_i == 8
-          return '3.5' if node['platform_version'].to_i == 16
-        when 'rhel'
-          return '2.6' if node['platform_version'].to_i == 5
-          return '3.1' if node['platform_version'].to_i == 6
-          return '3.3' if node['platform_version'].to_i == 7
-        when 'fedora'
-          return '3.5'
-        when 'freebsd'
-          return '3.5'
-        end
-      end
-
       # load them databags.
       def squid_load_host_acl(databag_name)
         host_acl = []

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,9 +40,6 @@ Chef::Log.debug("Squid host_acls: #{host_acl}")
 Chef::Log.debug("Squid url_acls: #{url_acl}")
 Chef::Log.debug("Squid acls: #{acls}")
 
-# packages
-package node['squid']['package']
-
 ruby_block 'Detect squid version' do
   block do
     Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
@@ -50,6 +47,13 @@ ruby_block 'Detect squid version' do
     command_out = shell_out(command)
     node.set['squid']['squid_version_detected'] = command_out.stdout.to_f
   end
+  action:nothing
+end
+
+# packages
+package 'Install squid package' do
+  package_name node['squid']['package']
+  notifies :create, 'ruby_block[Detect squid version]', :immediately
 end
 
 # rhel_family sysconfig

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,6 @@ end
 ipaddress = node['squid']['ipaddress']
 listen_interface = node['squid']['listen_interface']
 netmask = node['network']['interfaces'][listen_interface]['addresses'][ipaddress]['netmask']
-package_version = squid_version
 
 # squid/libraries/default.rb
 acls = squid_load_acls(node['squid']['acls_databag_name'])
@@ -37,13 +36,21 @@ url_acl = squid_load_url_acl(node['squid']['urls_databag_name'])
 Chef::Log.debug("Squid listen_interface: #{listen_interface}")
 Chef::Log.debug("Squid ipaddress: #{ipaddress}")
 Chef::Log.debug("Squid netmask: #{netmask}")
-Chef::Log.debug("Squid version: #{squid_version}")
 Chef::Log.debug("Squid host_acls: #{host_acl}")
 Chef::Log.debug("Squid url_acls: #{url_acl}")
 Chef::Log.debug("Squid acls: #{acls}")
 
 # packages
 package node['squid']['package']
+
+ruby_block 'Detect squid version' do
+  block do
+    Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
+    command = %(#{node['squid']['package']} -v | grep Version | sed 's/.*Version \\\(.\\..\\\).*/\\1/g' | tr -d '\n')
+    command_out = shell_out(command)
+    node.set['squid']['squid_version_detected'] = command_out.stdout.to_f
+  end
+end
 
 # rhel_family sysconfig
 template '/etc/sysconfig/squid' do
@@ -78,14 +85,18 @@ template node['squid']['config_file'] do
   notifies :reload, "service[#{node['squid']['service_name']}]"
   mode 00644
   variables(
-    host_acl: host_acl,
-    url_acl: url_acl,
-    acls: acls,
-    directives: node['squid']['directives'],
-    localnets: node['squid']['localnets'],
-    safe_ports: node['squid']['safe_ports'],
-    ssl_ports: node['squid']['ssl_ports'],
-    version: package_version
+    lazy {
+      {
+        host_acl: host_acl,
+        url_acl: url_acl,
+        acls: acls,
+        directives: node['squid']['directives'],
+        localnets: node['squid']['localnets'],
+        safe_ports: node['squid']['safe_ports'],
+        ssl_ports: node['squid']['ssl_ports'],
+        version: node['squid']['squid_version_detected']
+      }
+    }
   )
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,7 +85,7 @@ template node['squid']['config_file'] do
   notifies :reload, "service[#{node['squid']['service_name']}]"
   mode 00644
   variables(
-    lazy {
+    lazy do
       {
         host_acl: host_acl,
         url_acl: url_acl,
@@ -96,7 +96,7 @@ template node['squid']['config_file'] do
         ssl_ports: node['squid']['ssl_ports'],
         version: node['squid']['squid_version_detected']
       }
-    }
+    end
   )
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,7 @@ ruby_block 'Detect squid version' do
     Chef::Resource::RubyBlock.send(:include, Chef::Mixin::ShellOut)
     command = %(#{node['squid']['package']} -v | grep Version | sed 's/.*Version \\\(.\\..\\\).*/\\1/g' | tr -d '\n')
     command_out = shell_out(command)
-    node.set['squid']['squid_version_detected'] = command_out.stdout.to_f
+    node.normal['squid']['squid_version_detected'] = command_out.stdout.to_f
   end
   action:nothing
 end


### PR DESCRIPTION
### Description

Detect version of squid installed automatically. Before version of squid installed were hardcoded according to Linux distribution & version. It didn't work well since squid version is sometimes changed in the same distribution (e.g. Ubuntu 14).

Moreover bug with bad service name is fixed for Ubuntu 16.
### Issues Resolved

Issue #50 
Issue #67
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [n/a] New functionality includes testing.
- [n/a] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
