### PR TITLE
directive hierarchy_stoplist if squid version lt 3.5

### DIFF
--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -66,7 +66,7 @@ http_port <%= port %>
 http_port <%= node['squid']['port'] %>
 <% end %>
 
-hierarchy_stoplist cgi-bin ?
+<%= "hierarchy_stoplist cgi-bin ?" if @version.to_f < 3.5 %>
 
 <% node['squid']['logformats'].each do |name, format| %>
 logformat <%= name %> <%= format %>


### PR DESCRIPTION
### Description

Directive `hierarchy_stoplist` fails if squid version is >= 3.5

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
