### PR TITLE
Allow log_module to be configured for logging to syslog for example

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['squid']['config_dir'] = '/etc/squid'
 default['squid']['config_include_dir'] = nil   # '/etc/squid/conf.d'
 default['squid']['config_file'] = '/etc/squid/squid.conf'
 default['squid']['log_dir'] = '/var/log/squid'
+default['squid']['log_module'] = nil # e.g. syslog, stdio, or none (nil != none)
 default['squid']['cache_dir'] = '/var/spool/squid'
 default['squid']['coredump_dir'] = '/var/spool/squid'
 default['squid']['acl_element'] = 'url_regex'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -106,6 +106,7 @@ template node['squid']['config_file'] do
         acls: acls,
         directives: node['squid']['directives'],
         localnets: node['squid']['localnets'],
+        log_module: node['squid']['log_module'],
         safe_ports: node['squid']['safe_ports'],
         ssl_ports: node['squid']['ssl_ports'],
         version: node['squid']['squid_version_detected'],

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -72,7 +72,7 @@ http_port <%= node['squid']['port'] %>
 logformat <%= name %> <%= format %>
 <% end -%>
 
-access_log <%= node['squid']['log_dir'] %>/access.log <%= node['squid']['access_log_option'] %>
+access_log <%= !@log_module.nil? ? @log_module + ':' : '' %><%= node['squid']['log_dir'] %>/access.log <%= node['squid']['access_log_option'] %>
 refresh_pattern	    ^ftp:			1440	20%	10080
 refresh_pattern     ^gopher:			1440	0%	1440
 refresh_pattern	    -i (/cgi-bin/|\?)		0	0%	0


### PR DESCRIPTION
### Description

Allow log_module to be configured for logging


### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
