### PR TITLE
Use correct application directories for debian-based distros

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,12 +69,21 @@ default['squid']['ldap_authcredentialsttl'] = '1 minute' # Credentials TTL
 case node['platform_family']
 
 when 'debian'
-  default['squid']['package'] = 'squid3'
-  default['squid']['config_dir'] = '/etc/squid3'
-  default['squid']['config_file'] = '/etc/squid3/squid.conf'
-  default['squid']['log_dir'] = '/var/log/squid3'
-  default['squid']['cache_dir'] = '/var/spool/squid3'
-  default['squid']['coredump_dir'] = '/var/spool/squid3'
+  if node['platform_version'] =~ /^8|^14/
+    default['squid']['package'] = 'squid3'
+    default['squid']['config_dir'] = '/etc/squid3'
+    default['squid']['config_file'] = '/etc/squid3/squid.conf'
+    default['squid']['log_dir'] = '/var/log/squid3'
+    default['squid']['cache_dir'] = '/var/spool/squid3'
+    default['squid']['coredump_dir'] = '/var/spool/squid3'
+  else
+    default['squid']['package'] = 'squid'
+    default['squid']['config_dir'] = '/etc/squid'
+    default['squid']['config_file'] = '/etc/squid/squid.conf'
+    default['squid']['log_dir'] = '/var/log/squid'
+    default['squid']['cache_dir'] = '/var/spool/squid'
+    default['squid']['coredump_dir'] = '/var/spool/squid'
+  end
 
 when 'smartos'
   default['squid']['listen_interface'] = 'net0'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -49,7 +49,7 @@ module ChefSquidHelpers
   end
 
   def squid_service_name
-    if node['platform_family'] == 'debian' && node['platform_version'].to_i < 16
+    if node['platform_family'] == 'debian' && node['platform_version'] =~ /^8|^14/
       'squid3'
     else
       'squid'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -6,27 +6,27 @@ describe 'squid::default on Ubuntu 16.04' do
     end.converge('squid::default')
   end
 
-  it 'installs package squid3' do
-    expect(chef_run).to install_package('squid3')
+  it 'installs package squid' do
+    expect(chef_run).to install_package('squid')
   end
 
-  it 'templates /etc/squid3/squid.conf' do
-    expect(chef_run).to create_template('/etc/squid3/squid.conf')
+  it 'templates /etc/squid/squid.conf' do
+    expect(chef_run).to create_template('/etc/squid/squid.conf')
   end
 
-  it 'templates /etc/squid3/squid.conf http deny all' do
-    expect(chef_run).to render_file('/etc/squid3/squid.conf').with_content(
+  it 'templates /etc/squid/squid.conf http deny all' do
+    expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
       'http_access deny all'
     )
   end
 
-  it 'templates /etc/squid3/squid.conf icp deny all' do
-    expect(chef_run).to render_file('/etc/squid3/squid.conf').with_content(
+  it 'templates /etc/squid/squid.conf icp deny all' do
+    expect(chef_run).to render_file('/etc/squid/squid.conf').with_content(
       'icp_access deny all'
     )
   end
 
-  it 'templates /etc/squid3/squid.conf without include directory' do
+  it 'templates /etc/squid/squid.conf without include directory' do
     expect(chef_run).to_not render_file('/etc/squid/squid.conf').with_content(
       'Include additional configuration files'
     )


### PR DESCRIPTION
### Description

This adds some logic to use the correct directories based on which versions use the squid vs the squid3 name for debian-based platforms. The rspec ubuntu tests were updated to use the correct names as well.

### Issues Resolved
Fixes #72 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
