### PR TITLE
Avoid overlapping network definition on startup

### DIFF
--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -20,12 +20,6 @@ auth_param basic credentialsttl <%= node['squid']['ldap_authcredentialsttl'] %>
 acl localnet src <%= localnet %>
 <% end %>
 
-acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
-acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
-acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
-acl localnet src fc00::/7       # RFC4193 local private network range
-acl localnet src fe80::/10      # RFC4291 link-local (directly-plugged) machine
-
 <% @ssl_ports.each do |port| %>
 acl SSL_ports port <%= port %>
 <% end %>


### PR DESCRIPTION
Fix #71

Those static localnet entries are really not needed since they are in `default['squid']['localnets']`.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
