### PR TITLE
Test no warnings are printed on startup

### DIFF
--- a/test/integration/default/squid_spec.rb
+++ b/test/integration/default/squid_spec.rb
@@ -3,3 +3,13 @@ describe 'Squid server' do
     expect(port(3128)).to be_listening
   end
 end
+
+squid_syntax_check = 'sudo squid -k parse'
+if os[:family] == 'debian'
+  squid_syntax_check = 'sudo squid3 -k parse'
+end
+
+describe command(squid_syntax_check) do
+  its('exit_status') { should eq 0 }
+  its('stderr') { should_not match /WARNING/ }
+end


### PR DESCRIPTION
This is an assert to prevent https://github.com/chef-cookbooks/squid/pull/84 happening again.