### PR TITLE
Fix only_if test around config_include_dir.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -63,23 +63,24 @@ directory node['squid']['config_dir'] do
   mode '755'
 end
 
-# squid config include dir
-# will only create directory if config_include_dir attribute is not nil
-directory 'squid_config_include_dir' do
-  path node['squid']['config_include_dir']
-  action :create
-  recursive true
-  owner 'root'
-  mode '755'
-  only_if defined?(node['squid']['config_include_dir']).nil?
-end
+# only create directories if config_include_dir attribute is not nil
+unless node['squid']['config_include_dir'].nil?
 
-# squid dummy include
-# required, otherwise Squid will not start due to missing .conf files
-file 'squid_config_include_dir_dummy.conf' do
-  path "#{node['squid']['config_include_dir']}/dummy.conf"
-  content '# Dummy conf to enable Squid includes in conf.d'
-  only_if defined?(node['squid']['config_include_dir']).nil?
+  # squid config include dir
+  directory 'squid_config_include_dir' do
+    path node['squid']['config_include_dir']
+    action :create
+    recursive true
+    owner 'root'
+    mode '755'
+  end
+
+  # squid dummy include
+  # required, otherwise Squid will not start due to missing .conf files
+  file 'squid_config_include_dir_dummy.conf' do
+    path "#{node['squid']['config_include_dir']}/dummy.conf"
+    content '# Dummy conf to enable Squid includes in conf.d'
+  end
 end
 
 # squid mime config


### PR DESCRIPTION
Fix the only_if test around `config_include_dir` so that the squid cookbook can be run on Chef 13. This appears to have never worked correctly. The condition is backwards and doesn't work with all cases anyway. Regardless, in Chef 13 you can't pass nil as the path to a directory resource.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
