### PR TITLE
Add support for negated acls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the squid cookbook.
 
-## 4.1.0 (2018-05-10)
+## 4.1.0 (2018-05-23)
 
 - Allow us to optionally invert the ACL name by including an exclamation mark in an additional array element in the databag
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the squid cookbook.
 
+## 4.1.0 (2018-05-10)
+
+- Allow us to optionally invert the ACL name by including an exclamation mark in an additional array element in the databag
+
 ## 4.0.3 (2018-04-13)
 
 - Fix only_if test around config_include_dir.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Databags are able to be used for storing host & url acls and also which hosts/ne
       "allow"
     ],
     [
+      "yubikey",
+      "deny",
+      "!"
+    ],
+    [
       "all",
       "deny"
     ]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -39,7 +39,8 @@ module ChefSquidHelpers
         group = data_bag_item(databag_name, bag)
         next unless group['acl'].respond_to?(:each)
         group['acl'].each do |acl|
-          acls.push [acl[1], group['id'], acl[0]]
+          # An exclamation mark can be optionally included in the additional array element to invert the ACL
+          acls.push [acl[1], "#{acl[2] || ''}#{group['id']}", acl[0]]
         end
       end
     rescue

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs/configures squid as a simple caching proxy'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '4.0.3'
+version          '4.1.0'
 
 recipe 'squid::default', 'Installs and configures Squid.'
 


### PR DESCRIPTION
### Description

This small change allows us to configure inverted ACLs by optionally including an "!" in an additional array element in the databag.  When this element is present, it is appended to the front of the ACL name (the ACL name comes from the databag ID).

This change allows us to correctly configure inverted ACLs such as "!my-acl" in squid.conf (this is currently impossible because data bag IDs beginning with an exclamation mark are not valid).

New unit tests have been added to test the functionality.

### Issues Resolved

This resolves issue #68: squid_acls ID "not" operator broken

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>